### PR TITLE
Mark diagnostic entities as such

### DIFF
--- a/custom_components/sma_ennexos/sensor.py
+++ b/custom_components/sma_ennexos/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -29,6 +30,7 @@ from .base_entity import SMAEntity
 from .const import DOMAIN, LOGGER
 from .coordinator import SMADataCoordinator
 from .sma.known_channels import (
+    SMAChannelCategory,
     SMACumulativeMode,
     SMADeviceKind,
     SMAUnit,
@@ -172,6 +174,7 @@ class SMASensor(SMAEntity, SensorEntity):
         device_class = None
         unit_of_measurement = None
         state_class = SensorStateClass.MEASUREMENT
+        entity_category = None
         suggested_display_precision = None
         if known_channel is not None:
             icon = self.__device_kind_to_icon(known_channel.device_kind)
@@ -188,6 +191,12 @@ class SMASensor(SMAEntity, SensorEntity):
 
             suggested_display_precision = self.__unit_to_display_precision(
                 known_channel.unit
+            )
+
+            entity_category = (
+                EntityCategory.DIAGNOSTIC
+                if known_channel.category == SMAChannelCategory.DIAGNOSTIC
+                else None
             )
 
             # set enum_values if known channel is UNIT_ENUM
@@ -209,13 +218,14 @@ class SMASensor(SMAEntity, SensorEntity):
 
             LOGGER.debug(
                 "configuring %s@%s using known channel:"
-                "icon=%s, device_class=%s, unit_of_measurement=%s, state_class=%s, suggested_display_precision=%s",
+                "icon=%s, device_class=%s, unit_of_measurement=%s, state_class=%s, entity_category=%s, suggested_display_precision=%s",
                 self.component_id,
                 self.channel_id,
                 icon,
                 device_class,
                 unit_of_measurement,
                 state_class,
+                entity_category,
                 suggested_display_precision,
             )
         else:
@@ -242,6 +252,7 @@ class SMASensor(SMAEntity, SensorEntity):
             state_class=state_class,
             suggested_display_precision=suggested_display_precision,
             entity_registry_enabled_default=is_known_channel,
+            entity_category=entity_category,
         )
 
         # required for using translation_key

--- a/custom_components/sma_ennexos/sma/known_channels.py
+++ b/custom_components/sma_ennexos/sma/known_channels.py
@@ -61,13 +61,18 @@ class SMAChannelCategory(str, Enum):
     DIAGNOSTIC = "DIAGNOSTIC"
 
 
-__COMMON_ENUM_VALUES = {
+__CONNECTION_STATUS_ENUM_VALUES = {
     55: "communication_error",
+    307: "ok",
+    455: "warning",
+}
+
+__COMMON_ENUM_VALUES = {
+    **__CONNECTION_STATUS_ENUM_VALUES,
     303: "off",
     304: "island_operation",
     305: "island_operation",
     306: "island_operation",
-    307: "ok",
     308: "on",
     309: "operating",
     311: "open",
@@ -79,7 +84,6 @@ __COMMON_ENUM_VALUES = {
     318: "overload",
     319: "overtemperature",
     454: "calibration",
-    455: "warning",  #
     456: "waiting_for_dc_start_condition",
     457: "waiting_for_grid_voltage",
 }
@@ -454,6 +458,11 @@ __KNOWN_CHANNELS: dict[
         unit=SMAUnit.CELSIUS,
         category=SMAChannelCategory.DIAGNOSTIC,
     ),
+    "Measurement.Coolsys.Inverter.TmpVal[]": KnownChannelEntry(
+        device_kind=SMADeviceKind.OTHER,
+        unit=SMAUnit.CELSIUS,
+        category=SMAChannelCategory.DIAGNOSTIC,
+    ),
     "Measurement.Coolsys.Tr.TmpVal": KnownChannelEntry(
         device_kind=SMADeviceKind.OTHER,
         unit=SMAUnit.CELSIUS,
@@ -578,6 +587,18 @@ __KNOWN_CHANNELS: dict[
         device_kind=SMADeviceKind.OTHER,
         unit=SMAUnit.ENUM,
         enum_values=__COMMON_ENUM_VALUES,  # TODO: Measurement.MltFncSw.SttMstr enum_values may be partially incorrect, only [303] are validated
+    ),
+    "Measurement.Portal.EnnexOS.ConnStt": KnownChannelEntry(
+        device_kind=SMADeviceKind.OTHER,
+        unit=SMAUnit.ENUM,
+        category=SMAChannelCategory.DIAGNOSTIC,
+        enum_values=__CONNECTION_STATUS_ENUM_VALUES,  # TODO: Measurement.Portal.EnnexOS.ConnStt enum_values may be partially incorrect, only [307] are validated
+    ),
+    "Measurement.WebConn.Stt": KnownChannelEntry(
+        device_kind=SMADeviceKind.OTHER,
+        unit=SMAUnit.ENUM,
+        category=SMAChannelCategory.DIAGNOSTIC,
+        enum_values=__CONNECTION_STATUS_ENUM_VALUES,  # TODO: Measurement.WebConn.Stt enum_values may be partially incorrect, only [307] are validated
     ),
 }
 

--- a/custom_components/sma_ennexos/sma/known_channels.py
+++ b/custom_components/sma_ennexos/sma/known_channels.py
@@ -51,6 +51,16 @@ class SMACumulativeMode(str, Enum):
     MAXIMUM = "MAXIMUM"
 
 
+class SMAChannelCategory(str, Enum):
+    """SMA known channel categories."""
+
+    # a operational value, e.g. inverter power
+    OPERATIONAL = "OPERATIONAL"
+
+    # a diagnostic value, e.g. temperature, status or error count
+    DIAGNOSTIC = "DIAGNOSTIC"
+
+
 __COMMON_ENUM_VALUES = {
     55: "communication_error",
     303: "off",
@@ -87,6 +97,9 @@ class KnownChannelEntry:
 
     # optional cumulative mode
     cumulative_mode: SMACumulativeMode | None = None
+
+    # optional category of the channel
+    category: SMAChannelCategory = SMAChannelCategory.OPERATIONAL
 
     # optional list of enum values, only with unit=SMAUnit.ENUM
     enum_values: dict[int, str] | None = None
@@ -225,6 +238,7 @@ __KNOWN_CHANNELS: dict[
     "Measurement.Operation.CurAvailPlnt": KnownChannelEntry(
         device_kind=SMADeviceKind.OTHER,
         unit=SMAUnit.PERCENT,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Operation.CurAvailVArOvExt": KnownChannelEntry(
         device_kind=SMADeviceKind.OTHER,
@@ -245,6 +259,7 @@ __KNOWN_CHANNELS: dict[
     "Measurement.Operation.Health": KnownChannelEntry(
         device_kind=SMADeviceKind.OTHER,
         unit=SMAUnit.ENUM,
+        category=SMAChannelCategory.DIAGNOSTIC,
         enum_values=__COMMON_ENUM_VALUES,  # TODO: Measurement.Operation.Health enum_values may be partially incorrect, only [55, 307, 455] are validated
     ),
     "Measurement.Operation.WMaxInLimNom": KnownChannelEntry(
@@ -356,66 +371,80 @@ __KNOWN_CHANNELS: dict[
     "Measurement.Bat.Diag.ActlCapacNom": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.PERCENT,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Bat.Diag.CapacThrpCnt": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.PLAIN_NUMBER,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Bat.Diag.ChaAMax": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.AMPERE,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Bat.Diag.CntErrOvV": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.PLAIN_NUMBER,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.COUNTER,
     ),
     "Measurement.Bat.Diag.CntWrnOvV": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.PLAIN_NUMBER,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.COUNTER,
     ),
     "Measurement.Bat.Diag.CntWrnSOCLo": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.PLAIN_NUMBER,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.COUNTER,
     ),
     "Measurement.Bat.Diag.DschAMax": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.AMPERE,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Bat.Diag.StatTm": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.SECONDS,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Bat.Diag.TmpValMax": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.CELSIUS,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.MAXIMUM,
     ),
     "Measurement.Bat.Diag.TmpValMin": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.CELSIUS,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.MINIMUM,
     ),
     "Measurement.Bat.Diag.TotAhIn": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.AMPERE,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.TOTAL,
     ),
     "Measurement.Bat.Diag.TotAhOut": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.AMPERE,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.TOTAL,
     ),
     "Measurement.Bat.Diag.VolMax": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.VOLT,
+        category=SMAChannelCategory.DIAGNOSTIC,
         cumulative_mode=SMACumulativeMode.MAXIMUM,
     ),
     "Measurement.Bat.TmpVal": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY,
         unit=SMAUnit.CELSIUS,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Bat.Vol": KnownChannelEntry(
         device_kind=SMADeviceKind.BATTERY, unit=SMAUnit.VOLT
@@ -423,10 +452,12 @@ __KNOWN_CHANNELS: dict[
     "Measurement.Coolsys.Inverter.TmpVal": KnownChannelEntry(
         device_kind=SMADeviceKind.OTHER,
         unit=SMAUnit.CELSIUS,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.Coolsys.Tr.TmpVal": KnownChannelEntry(
         device_kind=SMADeviceKind.OTHER,
         unit=SMAUnit.CELSIUS,
+        category=SMAChannelCategory.DIAGNOSTIC,
     ),
     "Measurement.ExtGridMs.A.phsA": KnownChannelEntry(
         device_kind=SMADeviceKind.GRID,

--- a/custom_components/sma_ennexos/translations/de.json
+++ b/custom_components/sma_ennexos/translations/de.json
@@ -405,6 +405,22 @@
                     "waiting_for_dc_start_condition": "Warte auf DC-Startbedingung",
                     "waiting_for_grid_voltage": "Warte auf Netzspannung"
                 }
+            },
+            "measurement_portal_ennexos_connstt": {
+                "name": "Verbindungsstatus zum ennexOS Portal",
+                "state": {
+                    "communication_error": "Kommunikationsfehler",
+                    "ok": "OK",
+                    "warning": "Warnung"
+                }
+            },
+            "measurement_webconn_stt": {
+                "name": "Webverbindungsstatus",
+                "state": {
+                    "communication_error": "Kommunikationsfehler",
+                    "ok": "OK",
+                    "warning": "Warnung"
+                }
             }
         }
     }

--- a/custom_components/sma_ennexos/translations/en.json
+++ b/custom_components/sma_ennexos/translations/en.json
@@ -405,6 +405,22 @@
                     "waiting_for_dc_start_condition": "Waiting for DC Start Condition",
                     "waiting_for_grid_voltage": "Waiting for Grid Voltage"
                 }
+            },
+            "measurement_portal_ennexos_connstt": {
+                "name": "ennexOS Portal Connection Status",
+                "state": {
+                    "communication_error": "Communication Error",
+                    "ok": "OK",
+                    "warning": "Warning"
+                }
+            },
+            "measurement_webconn_stt": {
+                "name": "Web Connection Status",
+                "state": {
+                    "communication_error": "Communication Error",
+                    "ok": "OK",
+                    "warning": "Warning"
+                }
             }
         }
     }


### PR DESCRIPTION
Sets the entity_category for diagnostic sensors. additionally, some known_channels are added for diagnostic channels.