### PR TITLE
Initialize SMA sensor state from coordinator data

### DIFF
--- a/custom_components/sma_ennexos/sensor.py
+++ b/custom_components/sma_ennexos/sensor.py
@@ -137,6 +137,10 @@ class SMASensor(SMAEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         data = self.coordinator.data
 
+        # coordinator data may not be available yet on first call
+        if data is None:
+            return
+
         # find the ChannelValues of this sensor
         channel_values = next(
             (


### PR DESCRIPTION
## Summary

- initialize sensor state from existing coordinator data in `async_added_to_hass`
- remove the extra coordinator refresh during integration setup
- update the setup test to reflect the reduced login count

## Why

The coordinator performs its first refresh before sensor entities are added. The sensors only populated their native state inside `_handle_coordinator_update()`, so they missed that initial snapshot and stayed empty until the next scheduled refresh.

The current code works around that by forcing an extra coordinator refresh during setup, but that adds redundant API traffic and an extra login on every setup and reload.

By initializing the entity from the coordinator's already-fetched data when it is added to Home Assistant, the sensors have their initial state immediately and the extra setup refresh is no longer needed.
