### PR TITLE
Fix entity id umlaut handling (hass 2027.2.0)

### DIFF
--- a/custom_components/sma_ennexos/sensor.py
+++ b/custom_components/sma_ennexos/sensor.py
@@ -113,14 +113,14 @@ class SMASensor(SMAEntity, SensorEntity):
 
         # create entity id from device id and channel id
         #
-        # NOTE: we do this even tho homeassistant doesn't really recommends it, because
+        # NOTE: we do this although homeassistant doesn't really recommend it, because
         # we want to persist the channel id (e.g. "Measurement.GridMs.Hz") in the entity id,
         # and automatic id generation will not do that
         # (instead deriving it from the display name, which becomes unhelpful fast)...
         #
         # NOTE: entity id is generated twice here, once for the actual - user facing - entity id,
         # and a second one for uid generation.
-        # this is to ensure that, when updating to the new version of the intergations, existing
+        # this is to ensure that, when updating to the new version of the integration, existing
         # sensors are migrated over correctly and retain their history.
         eid_kwargs = {
             "component_name": component_info.name

--- a/custom_components/sma_ennexos/sensor.py
+++ b/custom_components/sma_ennexos/sensor.py
@@ -112,6 +112,10 @@ class SMASensor(SMAEntity, SensorEntity):
         self.channel_id = channel_id
 
         # create entity id from device id and channel id
+        # NOTE: we do this even tho homeassistant doesn't really recommends it, because
+        # we want to persist the channel id (e.g. "Measurement.GridMs.Hz") in the entity id,
+        # and automatic id generation will not do that
+        # (instead deriving it from the display name, which becomes unhelpful fast)...
         self.entity_id = channel_parts_to_entity_id(
             component_info.name if component_info is not None else self.component_id,
             channel_id,

--- a/custom_components/sma_ennexos/sensor.py
+++ b/custom_components/sma_ennexos/sensor.py
@@ -112,16 +112,30 @@ class SMASensor(SMAEntity, SensorEntity):
         self.channel_id = channel_id
 
         # create entity id from device id and channel id
+        #
         # NOTE: we do this even tho homeassistant doesn't really recommends it, because
         # we want to persist the channel id (e.g. "Measurement.GridMs.Hz") in the entity id,
         # and automatic id generation will not do that
         # (instead deriving it from the display name, which becomes unhelpful fast)...
+        #
+        # NOTE: entity id is generated twice here, once for the actual - user facing - entity id,
+        # and a second one for uid generation.
+        # this is to ensure that, when updating to the new version of the intergations, existing
+        # sensors are migrated over correctly and retain their history.
+        eid_kwargs = {
+            "component_name": component_info.name
+            if component_info is not None
+            else self.component_id,
+            "channel_id": channel_id,
+            "kind": "sensor",
+        }
         self.entity_id = channel_parts_to_entity_id(
-            component_info.name if component_info is not None else self.component_id,
-            channel_id,
-            "sensor",
+            **eid_kwargs, normalization="default"
         )
-        self._attr_unique_id = str(uuid.uuid5(uuid.NAMESPACE_X500, self.entity_id))
+        entity_id_for_uid = channel_parts_to_entity_id(
+            **eid_kwargs, normalization="old"
+        )
+        self._attr_unique_id = str(uuid.uuid5(uuid.NAMESPACE_X500, entity_id_for_uid))
 
         # super handles setting id and device_info for us
         super().__init__(

--- a/custom_components/sma_ennexos/util.py
+++ b/custom_components/sma_ennexos/util.py
@@ -10,8 +10,21 @@ def __normalize_for_id(s: str) -> str:
     for c in " -.:":
         s = s.replace(c, "_")
 
-    # remove all non-alphanumeric characters except underscores
-    s = "".join(c if c.isalnum() or c == "_" else "" for c in s)
+    # replace umlauts with ascii equivalents
+    UMLAUT_REPLACEMENTS = {
+        "ä": "ae",
+        "ö": "oe",
+        "ü": "ue",
+        "ß": "ss",
+    }
+    for umlaut, replacement in UMLAUT_REPLACEMENTS.items():
+        s = s.replace(umlaut, replacement)
+
+    # filter to only allow allowed characters (a-z, 0-9, and underscore)
+    def is_allowed_char(c: str) -> bool:
+        return c.isnumeric() or (c.isalpha() and c >= "a" and c <= "z") or c == "_"
+
+    s = "".join(c if is_allowed_char(c) else "" for c in s)
 
     # trim underscores from start and end
     s = s.strip("_")

--- a/custom_components/sma_ennexos/util.py
+++ b/custom_components/sma_ennexos/util.py
@@ -1,7 +1,9 @@
 """integration utilities."""
 
+from typing import Literal
 
-def __normalize_for_id(s: str) -> str:
+
+def __normalize_for_id_old(s: str) -> str:
     """Normalize a string for use in an entity id or translation key."""
     # lower case
     s = s.lower()
@@ -9,6 +11,23 @@ def __normalize_for_id(s: str) -> str:
     # replace "delimiting characters" and spaces with underscores
     for c in " -.:":
         s = s.replace(c, "_")
+
+    # remove all non-alphanumeric characters except underscores
+    s = "".join(c if c.isalnum() or c == "_" else "" for c in s)
+
+    # trim underscores from start and end
+    s = s.strip("_")
+
+    # remove all occurrences of multiple underscores
+    while "__" in s:
+        s = s.replace("__", "_")
+
+    return s
+
+
+def __normalize_for_id(s: str) -> str:
+    """Normalize a string for use in an entity id or translation key."""
+    s = __normalize_for_id_old(s)
 
     # replace umlauts with ascii equivalents
     UMLAUT_REPLACEMENTS = {
@@ -26,23 +45,23 @@ def __normalize_for_id(s: str) -> str:
 
     s = "".join(c if is_allowed_char(c) else "" for c in s)
 
-    # trim underscores from start and end
-    s = s.strip("_")
-
-    # remove all occurrences of multiple underscores
-    while "__" in s:
-        s = s.replace("__", "_")
-
     return s
 
 
-def channel_parts_to_entity_id(component_name: str, channel_id: str, kind: str) -> str:
+def channel_parts_to_entity_id(
+    component_name: str,
+    channel_id: str,
+    kind: str,
+    normalization: Literal["old"] | Literal["default"] = "default",
+) -> str:
     """
     Convert a channel_id and component_id to an entity id.
 
     :param component_name: The name or id of the component.
     :param channel_id: The channel_id of the channel.
     :param kind: The kind of entity. e.g. sensor, binary_sensor, etc.
+    :param normalization: The normalization method to use. "old" matches sma-ennexos behavior up to 2.1.4, while full handles umlauts correctly.
+    this option was added *ONLY* to be used in sensor uid generation. any other caller should use the default "full" version!
     :return: entity id
     """
     # transform array index to be just a suffix
@@ -52,7 +71,11 @@ def channel_parts_to_entity_id(component_name: str, channel_id: str, kind: str) 
     # concat component and channel id
     s = f"{component_name}_{channel_id}"
 
-    s = __normalize_for_id(s)
+    if normalization == "old":
+        s = __normalize_for_id_old(s)
+    else:
+        s = __normalize_for_id(s)
+
     return f"{kind}.{s}"
 
 

--- a/custom_components/sma_ennexos/util.py
+++ b/custom_components/sma_ennexos/util.py
@@ -41,9 +41,13 @@ def __normalize_for_id(s: str) -> str:
 
     # filter to only allow allowed characters (a-z, 0-9, and underscore)
     def is_allowed_char(c: str) -> bool:
-        return c.isnumeric() or (c.isalpha() and c >= "a" and c <= "z") or c == "_"
+        return ("0" <= c <= "9") or ("a" <= c <= "z") or c == "_"
 
     s = "".join(c if is_allowed_char(c) else "" for c in s)
+
+    # remove all occurrences of multiple underscores
+    while "__" in s:
+        s = s.replace("__", "_")
 
     return s
 
@@ -60,8 +64,8 @@ def channel_parts_to_entity_id(
     :param component_name: The name or id of the component.
     :param channel_id: The channel_id of the channel.
     :param kind: The kind of entity. e.g. sensor, binary_sensor, etc.
-    :param normalization: The normalization method to use. "old" matches sma-ennexos behavior up to 2.1.4, while full handles umlauts correctly.
-    this option was added *ONLY* to be used in sensor uid generation. any other caller should use the default "full" version!
+    :param normalization: The normalization method to use. "old" matches sma-ennexos behavior up to 2.1.4, while "default" handles umlauts correctly.
+    this option was added *ONLY* to be used in sensor uid generation. any other caller should use the default "default" version!
     :return: entity id
     """
     # transform array index to be just a suffix

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -51,6 +51,22 @@ def test_channel_parts_to_entity_id_umlauts():
     assert channel_parts_to_entity_id("Test ☀️☀️", "test", "sensor") == "sensor.test_test"
 
 
+def test_channel_parts_to_entity_id_umlauts_old():
+    """
+    Test entity ids are created as expected when umlauts and other special characters are involved, using the old normalization method.
+
+    This is to verify that, with the update, existing sensors are not broken.
+    """
+    assert (
+        channel_parts_to_entity_id("Mein Gerät", "Measurement.GridMs.Hz", "sensor", normalization="old")
+        == "sensor.mein_gerät_measurement_gridms_hz"
+    )
+    assert (
+        channel_parts_to_entity_id("Test äöüß!", "ch.äöüß", "sensor", normalization="old")
+        == "sensor.test_äöüß_ch_äöüß"
+    )
+
+
 def test_channel_id_to_translation_key():
     """Test channel_ids are converted to translation keys as expected."""
     assert (

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -49,8 +49,7 @@ def test_channel_parts_to_entity_id_umlauts():
 
     # eastern arabic numerals and other weirdness should be dropped
     assert (
-        channel_parts_to_entity_id("Test ١٨زب", "ch.a", "sensor")
-        == "sensor.test_ch_a"
+        channel_parts_to_entity_id("Test ١٨زب", "ch.a", "sensor") == "sensor.test_ch_a"
     )
 
     # if you do this, i hate you
@@ -64,11 +63,15 @@ def test_channel_parts_to_entity_id_umlauts_old():
     This is to verify that, with the update, existing sensors are not broken.
     """
     assert (
-        channel_parts_to_entity_id("Mein Gerät", "Measurement.GridMs.Hz", "sensor", normalization="old")
+        channel_parts_to_entity_id(
+            "Mein Gerät", "Measurement.GridMs.Hz", "sensor", normalization="old"
+        )
         == "sensor.mein_gerät_measurement_gridms_hz"
     )
     assert (
-        channel_parts_to_entity_id("Test äöüß!", "ch.äöüß", "sensor", normalization="old")
+        channel_parts_to_entity_id(
+            "Test äöüß!", "ch.äöüß", "sensor", normalization="old"
+        )
         == "sensor.test_äöüß_ch_äöüß"
     )
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -30,6 +30,27 @@ def test_channel_parts_to_entity_id():
     )
 
 
+def test_channel_parts_to_entity_id_umlauts():
+    """
+    Test entity ids are created as expected when umlauts and other special characters are involved.
+
+    SMA device names support umlauts (in fact, german installations [by lazy electricians] default their name to "Mein Gerät"),
+    but homeassistant entity ids only support ascii characters (a-z, 0-9, and underscores).
+    until now, homeassistant would automatically fix the ids for us, but starting in 2027.2.0, this is deprecated.
+    """
+    assert (
+        channel_parts_to_entity_id("Mein Gerät", "Measurement.GridMs.Hz", "sensor")
+        == "sensor.mein_geraet_measurement_gridms_hz"
+    )
+    assert (
+        channel_parts_to_entity_id("Test äöüß!", "ch.äöüß", "sensor")
+        == "sensor.test_aeoeuess_ch_aeoeuess"
+    )
+
+    # if you do this, i hate you
+    assert channel_parts_to_entity_id("Test ☀️☀️", "test", "sensor") == "sensor.test_test"
+
+
 def test_channel_id_to_translation_key():
     """Test channel_ids are converted to translation keys as expected."""
     assert (

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -47,6 +47,12 @@ def test_channel_parts_to_entity_id_umlauts():
         == "sensor.test_aeoeuess_ch_aeoeuess"
     )
 
+    # eastern arabic numerals and other weirdness should be dropped
+    assert (
+        channel_parts_to_entity_id("Test ١٨زب", "ch.a", "sensor")
+        == "sensor.test_ch_a"
+    )
+
     # if you do this, i hate you
     assert channel_parts_to_entity_id("Test ☀️☀️", "test", "sensor") == "sensor.test_test"
 


### PR DESCRIPTION
updates umlaut handling of `channel_parts_to_entity_id` to correctly handle umlauts.

fixes deprecation notice for hass 2027.2.0:

> 2026-05-27 13:13:15.532 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'sma_ennexos' sets an invalid entity ID: 'sensor.mein_gerät_setpoint_plantcontrol_inverter_wmodcfg_wctlcomcfg_wsptminnom'. In most cases, entities should not set entity_id, but if they do, it should be a valid entity ID.. This will stop working in Home Assistant 2027.2.0, please create a bug report at https://github.com/shadow578/homeassistant_sma-ennexos/issues